### PR TITLE
Fixed ElvUI Options error due to ElvUI Options changes.

### DIFF
--- a/ElvUI_Enhanced.toc
+++ b/ElvUI_Enhanced.toc
@@ -1,7 +1,7 @@
 ## Interface: 80300
 ## Title: |cff1784d1ElvUI|r Enhanced (BfA)
 ## Author: Feraldin
-## X-Credits: Instant, Tristimdorio (Omega1970), Azilroka, Lockslap, Sortokk, Repooc, moresunders
+## X-Credits: Instant, Tristimdorio (Omega1970), Azilroka, Crackpotx, Sortokk, Repooc, moresunders
 ## Version: 3.4.3
 ## Notes: Plugin-Enhancements for |cff1784d1ElvUI|r.
 ## X-Category: Plugins

--- a/config/options.lua
+++ b/config/options.lua
@@ -527,7 +527,7 @@ function EO:RaidMarkerOptions()
 end
 
 function EO:TooltipOptions()
-	E.Options.args.tooltip.args.general.args.progressInfo = {
+	E.Options.args.tooltip.args.progressInfo = {
 		order = 8,
 		type = 'toggle',
 		name = ColorizeSettingName(L['Progression Info']),
@@ -579,7 +579,7 @@ function EO:UnitFramesOptions()
 	}
 
 	--Target
-	E.Options.args.unitframe.args.target.args.gps = {
+	E.Options.args.unitframe.args.individualUnits.args.target.args.gps = {
 		order = 1000,
 		type = 'group',
 		name = ColorizeSettingName(L['GPS']),
@@ -601,7 +601,7 @@ function EO:UnitFramesOptions()
 		},
 	}
 	
-	E.Options.args.unitframe.args.target.args.attackicon = {
+	E.Options.args.unitframe.args.individualUnits.args.target.args.attackicon = {
 		order = 1001,
 		type = 'group',
 		name = ColorizeSettingName(L['Attack Icon']),
@@ -629,7 +629,7 @@ function EO:UnitFramesOptions()
 		},
 	}	
 	
-	E.Options.args.unitframe.args.target.args.classicon = {
+	E.Options.args.unitframe.args.individualUnits.args.target.args.classicon = {
 		order = 1002,
 		type = 'group',
 		name = ColorizeSettingName(L["Class Icons"]),
@@ -666,7 +666,7 @@ function EO:UnitFramesOptions()
 
 	
 	--Focus
-	E.Options.args.unitframe.args.focus.args.gps = {
+	E.Options.args.unitframe.args.individualUnits.args.focus.args.gps = {
 		order = 1000,
 		type = 'group',
 		name = ColorizeSettingName(L['GPS']),


### PR DESCRIPTION
Opening ElvUI's new options UI would generate errors mentioned in various issues that were opened, and it would also break other addons that hooked into EUI's Options UI as well. The hierarchy for `E.Options` has changed, which is the reason for the errors. Updated them to the proper locations and everything now functions as intended.