### PR TITLE
Fixed Minimap Button Bar Icons Messed up #132

### DIFF
--- a/modules/maps/minimapbuttons.lua
+++ b/modules/maps/minimapbuttons.lua
@@ -153,8 +153,10 @@ function MB:SkinButton(frame)
 			end
 			if (region:GetObjectType() == "Texture") then
 				local texture = region:GetTexture()
-
-				if (texture and (type(texture) ~= "number") and (texture:find("Border") or texture:find("Background") or texture:find("AlphaMask"))) then
+				
+				if (texture and (type(texture) == "number" and (texture == 136477 or texture == 136430 or texture == 136467))) then
+					region:SetTexture(nil)
+				elseif (texture and (type(texture) ~= "number" and (texture:find("Border") or texture:find("Background") or texture:find("AlphaMask")))) then	
 					region:SetTexture(nil)
 				else
 					region:ClearAllPoints()


### PR DESCRIPTION
Here is the fix for #132. It just strips the textures for 136577, 136430, and 136467, which are the default minimap textures.

I suppose I could have nested it into the original if statement, but that would be annoying to read.