### PR TITLE
Fix blank buttons when TomTom waypoints are saved.

### DIFF
--- a/modules/maps/minimapbuttons.lua
+++ b/modules/maps/minimapbuttons.lua
@@ -49,6 +49,7 @@ local partialIgnores = {
 	"Pin",
 	"POI",
 	"Questie",
+	"TTMinimapButton",
 }
 
 local whiteList = {


### PR DESCRIPTION
Here is the fix for #147.